### PR TITLE
Add GitHub Pages setting change step

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A really simple JS redirect for your social media links
 ## Deployment
 1. Fork this repo
 2. Change the `index.html` files in each folder (and add more folders!)
-3. Go to the `Actions` tab and click the `I understand my workflows, go ahead and enable them` button to get your site deploying!
+3. Go to the `Settings` tab, select `GitHub Actions` option from the `Source` dropdown list.
+4. Go to the `Actions` tab and click the `I understand my workflows, go ahead and enable them` button to get your site deploying!
 
 ## Usage
 


### PR DESCRIPTION
Not sure how universal this would be for new forks, but without this step, my first deploy workflow [failed with a status code 403 AxiosError](https://github.com/patridge/to/actions/runs/3825132949) that didn't make a lot of sense. The initial value for me was **Deploy from a branch**.

![GitHub screenshot showing GitHub Pages settings with the GitHub Actions source option shown.](https://user-images.githubusercontent.com/713665/210278527-70e21d86-074b-433d-aebb-22be4fcd8336.png)
